### PR TITLE
Reconnect links to better ports

### DIFF
--- a/samples/SharedDemo/Demos/ReconnectLink.razor
+++ b/samples/SharedDemo/Demos/ReconnectLink.razor
@@ -1,0 +1,27 @@
+﻿@page "/demos/reconnectlink"
+@inherits ReconnectLinkComponent
+@layout DemoLayout
+@inject LayoutData LayoutData
+
+@code {
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        LayoutData.Title = "Reconnect link";
+        LayoutData.Info = "An example of reconnecting links to better ports.";
+        LayoutData.DataChanged();
+    }
+}
+
+<div style="position: absolute; z-index: 9999;">
+    <button @onclick="ReconnectLinks">Reconnect links</button>
+</div>
+
+<CascadingValue Name="DiagramManager" Value="diagramManager">
+    <DiagramCanvas>
+        <Widgets>
+            <Navigator Width="300" Height="200" DefaultStyle="true"></Navigator>
+        </Widgets>
+    </DiagramCanvas>
+</CascadingValue>

--- a/samples/SharedDemo/Demos/ReconnectLinkComponent.cs
+++ b/samples/SharedDemo/Demos/ReconnectLinkComponent.cs
@@ -1,0 +1,40 @@
+﻿using Blazor.Diagrams.Core;
+using Blazor.Diagrams.Core.Models;
+using Blazor.Diagrams.Core.Models.Core;
+using Microsoft.AspNetCore.Components;
+
+namespace SharedDemo
+{
+    public class ReconnectLinkComponent:ComponentBase
+    {
+        protected readonly DiagramManager diagramManager = new DiagramManager();
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+
+            var node1 = NewNode(50, 50);
+            var node2 = NewNode(300, 300);
+            var node3 = NewNode(300, 50);
+            diagramManager.AddLink(node1.GetPort(PortAlignment.Top), node2.GetPort(PortAlignment.Right));
+            diagramManager.AddLink(node1.GetPort(PortAlignment.Bottom), node3.GetPort(PortAlignment.Top));
+            diagramManager.AddNode(node1);
+            diagramManager.AddNode(node2);
+            diagramManager.AddNode(node3);
+        }
+
+
+        protected void ReconnectLinks() => diagramManager.ReconnectAllLinks();
+
+
+        private NodeModel NewNode(double x, double y)
+        {
+            var node = new NodeModel(new Point(x, y));
+            node.AddPort(PortAlignment.Bottom);
+            node.AddPort(PortAlignment.Top);
+            node.AddPort(PortAlignment.Left);
+            node.AddPort(PortAlignment.Right);
+            return node;
+        }
+    }
+}

--- a/samples/SharedDemo/Layouts/DemoLayout.razor
+++ b/samples/SharedDemo/Layouts/DemoLayout.razor
@@ -39,6 +39,7 @@
             <a href="demos/zoomtofit" class="list-group-item list-group-item-action bg-light">Zoom to fit</a>
             <a href="demos/snaptogrid" class="list-group-item list-group-item-action bg-light">Snap to Grid</a>
             <a href="demos/grouping" class="list-group-item list-group-item-action bg-light">Grouping</a>
+            <a href="demos/reconnectlink" class="list-group-item list-group-item-action bg-light">Reconnect links</a>
 
             <div class="list-group-item bg-primary text-light">Customization</div>
             <a href="demos/custom-node" class="list-group-item list-group-item-action bg-light">Custom node</a>

--- a/src/Blazor.Diagrams.Core/DiagramManager.cs
+++ b/src/Blazor.Diagrams.Core/DiagramManager.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Blazor.Diagrams.Core.Extensions;
 
 [assembly: InternalsVisibleTo("Blazor.Diagrams")]
 namespace Blazor.Diagrams.Core
@@ -107,10 +108,23 @@ namespace Blazor.Diagrams.Core
         public LinkModel AddLink(PortModel source, PortModel? target = null)
             => AddLink<LinkModel>(source, target);
 
+
         public T AddLink<T>(PortModel source, PortModel? target = null) where T : LinkModel
         {
             var link = (T)Activator.CreateInstance(typeof(T), source, target);
             link.Type = Options.Links.DefaultLinkType;
+            return ConnectLinktoPorts(link, source, target);
+        }
+
+        public T AddLink<T>(T link) where T :LinkModel
+        {
+            var source = link.SourcePort;
+            var target = link.TargetPort;
+            return ConnectLinktoPorts(link, source, target);
+        }
+
+        private T ConnectLinktoPorts<T>(T link, PortModel source, PortModel? target) where T : LinkModel
+        {
             source.AddLink(link);
 
             if (target == null)
@@ -130,6 +144,7 @@ namespace Blazor.Diagrams.Core
             return link;
         }
 
+
         public void AttachLink(LinkModel link, PortModel targetPort)
         {
             if (link.IsAttached)
@@ -139,7 +154,6 @@ namespace Blazor.Diagrams.Core
                 return;
 
             link.SetTargetPort(targetPort);
-            targetPort.AddLink(link);
             link.Refresh();
             targetPort.Refresh();
             LinkAttached?.Invoke(link);
@@ -364,5 +378,14 @@ namespace Blazor.Diagrams.Core
         internal void OnKeyDown(KeyboardEventArgs e) => KeyDown?.Invoke(e);
 
         internal void OnWheel(WheelEventArgs e) => Wheel?.Invoke(e);
+
+        public void ReconnectAllLinks()
+        {
+            var linkModels = AllLinks.ToList();
+            foreach (var link in linkModels)
+            {
+                link.Reconnect();
+            }
+        }
     }
 }

--- a/src/Blazor.Diagrams.Core/Extensions/LinkModelExtensions.cs
+++ b/src/Blazor.Diagrams.Core/Extensions/LinkModelExtensions.cs
@@ -87,5 +87,47 @@ namespace Blazor.Diagrams.Core.Extensions
 
         public static double GetMiddleTargetY(this LinkModel link)
             => link.TargetPort!.Position.Y + (link.SourcePort.Size.Height / 2);
+
+
+
+        /// <summary>
+        /// Reconnects the link to the ports that are closest in distance for the link's nodes.
+        /// </summary>
+        /// <param name="link"></param>
+        /// <returns>The reconnected LinkModel entitiy</returns>
+        public static T Reconnect<T>(this T link) where T:LinkModel
+        {
+            if (link.TargetPort == null)
+            {
+                return link;
+            }
+
+            var sourcePorts = link.SourcePort.Parent.Ports;
+            var targetPorts = link.TargetPort.Parent.Ports;
+
+            //Find the ports with minimal distance
+            var minDistance = double.MaxValue;
+            var minSourcePort = link.SourcePort;
+            var minTargetPort = link.TargetPort;
+            foreach (var sourcePort in sourcePorts)
+            {
+                foreach (var targetPort in targetPorts)
+                {
+                    var distance = sourcePort.GetDistance(targetPort);
+                    if (distance < minDistance)
+                    {
+                        minDistance = distance;
+                        minSourcePort = sourcePort;
+                        minTargetPort = targetPort;
+                    }
+                }
+            }
+
+            //Reconnect
+            link.SetSourcePort(minSourcePort);
+            link.SetTargetPort(minTargetPort);
+
+            return link;
+        }
     }
 }

--- a/src/Blazor.Diagrams.Core/Extensions/PortModelModelExtensions.cs
+++ b/src/Blazor.Diagrams.Core/Extensions/PortModelModelExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Blazor.Diagrams.Core.Models;
+
+namespace Blazor.Diagrams.Core.Extensions
+{
+    public static class PortModelModelExtensions
+    {
+        /// <summary>
+        /// Gets the distance between two ports.
+        /// </summary>
+        /// <param name="thisPort"></param>
+        /// <param name="port"></param>
+        /// <returns></returns>
+        public static double GetDistance(this PortModel thisPort, PortModel port)
+        {
+            //Good old Pythagoras
+            var xDistance = Math.Abs(thisPort.Position.X - port.Position.X);
+            var yDistance = Math.Abs(thisPort.Position.Y - port.Position.Y);
+            return Math.Sqrt(xDistance * xDistance + yDistance * yDistance);
+        }
+    }
+}

--- a/src/Blazor.Diagrams.Core/Models/LinkModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/LinkModel.cs
@@ -18,24 +18,29 @@ namespace Blazor.Diagrams.Core.Models
         }
 
         public LinkType Type { get; set; }
-        public PortModel SourcePort { get; }
+        public PortModel SourcePort { get; private set; }
         public PortModel? TargetPort { get; private set; }
         public bool IsAttached => TargetPort != null;
         public Point? OnGoingPosition { get; set; }
 
+        public void SetSourcePort(PortModel port)
+        {
+            if (port != SourcePort)
+            {
+                SourcePort.RemoveLink(this);
+                port.AddLink(this);
+                SourcePort = port;
+            }
+        }
+        
         public void SetTargetPort(PortModel port)
         {
-            if (IsAttached)
-                return;
-
-            TargetPort = port;
+            if (port != TargetPort)
+            {
+                TargetPort?.RemoveLink(this);
+                port.AddLink(this);
+                TargetPort = port;
+            }
         }
-    }
-
-    public enum LinkType
-    {
-        Curved,
-        Line,
-        LineWithArrowToTarget
     }
 }

--- a/src/Blazor.Diagrams.Core/Models/LinkType.cs
+++ b/src/Blazor.Diagrams.Core/Models/LinkType.cs
@@ -1,0 +1,9 @@
+﻿namespace Blazor.Diagrams.Core.Models
+{
+    public enum LinkType
+    {
+        Curved,
+        Line,
+        LineWithArrowToTarget
+    }
+}

--- a/src/Blazor.Diagrams.Core/Models/PortModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/PortModel.cs
@@ -44,8 +44,16 @@ namespace Blazor.Diagrams.Core.Models
 
         public virtual bool CanAttachTo(PortModel port) => port != this && !port.Locked && Parent != port.Parent;
 
-        internal void AddLink(LinkModel link) => _links.Add(link);
+        internal void AddLink(LinkModel link)
+        {
+            _links.Add(link);
+            Refresh();
+        }
 
-        internal void RemoveLink(LinkModel link) => _links.Remove(link);
+        internal void RemoveLink(LinkModel link)
+        {
+            _links.Remove(link);
+            Refresh();
+        }
     }
 }


### PR DESCRIPTION
I Hi.
I am trying out Blazor.Digrams to generate some automatic documentation for a  microservices architecture, and needed some easy way to reconnect links to betters better ports after moving nodes around. So I implemented this reconnect feature.

Basically **DiagramManger.ReconnectAllLinks()** resets the SourcePort and TargetPort for all the links to the ones that have the shortest distance between them for the source and target nodes. There is a demo page for this in this commit

Resetting source and target ports for a link was not allowed before, so I changed that. Resetting target port was explicitly not allowed, so maybe this breaks a bit with how you want things to be?

I also added a **DiamgramManager.AddLink(LinkModel link)** since I found myself generating links elsewhere and was not able to add them directly.

(also note that in **DiamgramManager.AttachLink(LinkModel link, PortModel targetPort)** I have removed a **targetPort.AddLink(link)** call. This might look like a mistake but should be ok since I haved moved the targetPort.AddLink inside the **link.SetTargetPort(targetPort)** method)
