### PR TITLE
Adjusting curved link paths based on port Alignment

### DIFF
--- a/samples/SharedDemo/Demos/DynamicInsertions.razor.cs
+++ b/samples/SharedDemo/Demos/DynamicInsertions.razor.cs
@@ -41,26 +41,15 @@ namespace SharedDemo.Demos
                 return;
 
             var node = model as NodeModel;
-            if (node.GetPort(PortAlignment.Top) == null)
+            foreach(PortAlignment portAlignment in Enum.GetValues(typeof(PortAlignment)))
             {
-                node.AddPort(PortAlignment.Top);
-                node.Refresh();
-            }
-            else if (node.GetPort(PortAlignment.Right) == null)
-            {
-                node.AddPort(PortAlignment.Right);
-                node.Refresh();
-            }
-            else if (node.GetPort(PortAlignment.Bottom) == null)
-            {
-                node.AddPort(PortAlignment.Bottom);
-                node.Refresh();
-            }
-            else if (node.GetPort(PortAlignment.Left) == null)
-            {
-                node.AddPort(PortAlignment.Left);
-                node.Refresh();
-            }
+                if(node.GetPort(portAlignment) == null)
+                {
+                    node.AddPort(portAlignment);
+                    node.Refresh();
+                    break;
+                }
+            }            
         }
 
         protected void RemovePort()

--- a/src/Blazor.Diagrams.Core/Extensions/LinkModelExtensions.cs
+++ b/src/Blazor.Diagrams.Core/Extensions/LinkModelExtensions.cs
@@ -63,24 +63,25 @@ namespace Blazor.Diagrams.Core.Extensions
         private const double Margin = 125;
         private static string GetCurvePoint(double pX, double pY, double cX, double cY, PortAlignment? alignment)
         {
+            var margin = Math.Min(Margin, Math.Pow(Math.Pow(pX - cX, 2) + Math.Pow(pY - cY, 2), .5));
             switch (alignment)
             {
                 case PortAlignment.Top:
-                    return FormattableString.Invariant($"{pX} {Math.Min(pY - Margin, cY)}");
+                    return FormattableString.Invariant($"{pX} {Math.Min(pY - margin, cY)}");
                 case PortAlignment.Bottom:
-                    return FormattableString.Invariant($"{pX} {Math.Max(pY + Margin, cY)}");
+                    return FormattableString.Invariant($"{pX} {Math.Max(pY + margin, cY)}");
                 case PortAlignment.TopRight:
-                    return FormattableString.Invariant($"{Math.Max(pX + Margin, cX)} {Math.Min(pY - Margin, cY)}");
+                    return FormattableString.Invariant($"{Math.Max(pX + margin, cX)} {Math.Min(pY - margin, cY)}");
                 case PortAlignment.BottomRight:
-                    return FormattableString.Invariant($"{Math.Max(pX + Margin, cX)} {Math.Max(pY + Margin, cY)}");                    
+                    return FormattableString.Invariant($"{Math.Max(pX + margin, cX)} {Math.Max(pY + margin, cY)}");                    
                 case PortAlignment.Right:
-                    return FormattableString.Invariant($"{Math.Max(pX + Margin, cX)} {pY}");
+                    return FormattableString.Invariant($"{Math.Max(pX + margin, cX)} {pY}");
                 case PortAlignment.Left:
-                    return FormattableString.Invariant($"{Math.Min(pX - Margin, cX)} {pY}");
+                    return FormattableString.Invariant($"{Math.Min(pX - margin, cX)} {pY}");
                 case PortAlignment.BottomLeft:
-                    return FormattableString.Invariant($"{Math.Min(pX - Margin, cX)} {Math.Max(pY + Margin, cY)}");
+                    return FormattableString.Invariant($"{Math.Min(pX - margin, cX)} {Math.Max(pY + margin, cY)}");
                 case PortAlignment.TopLeft:
-                    return FormattableString.Invariant($"{Math.Min(pX - Margin, cX)} {Math.Min(pY - Margin, cY)}");
+                    return FormattableString.Invariant($"{Math.Min(pX - margin, cX)} {Math.Min(pY - margin, cY)}");
             }
             return FormattableString.Invariant($"{cX} {cY}");
         }

--- a/src/Blazor.Diagrams.Core/Extensions/LinkModelExtensions.cs
+++ b/src/Blazor.Diagrams.Core/Extensions/LinkModelExtensions.cs
@@ -30,7 +30,7 @@ namespace Blazor.Diagrams.Core.Extensions
                 return link.OnGoingPosition!.Y;
 
             return link.GetMiddleTargetY();
-        }
+        }       
 
         public static string GenerateCurvedPath(this LinkModel link)
         {
@@ -49,9 +49,20 @@ namespace Blazor.Diagrams.Core.Extensions
                 tY = link.OnGoingPosition.Y;
             }
 
+            var cX = (sX + tX) / 2;
+            var cY = (sY + tY) / 2;
+
+            var curvePoint1 = (link.SourcePort.Alignment == PortAlignment.Left || link.SourcePort.Alignment == PortAlignment.Right) ?
+                $"{cX.ToInvariantString()} {sY.ToInvariantString()}" :
+                $"{sX.ToInvariantString()} {cY.ToInvariantString()}";
+            
+            var cuvePoint2 = (!link.IsAttached || link.TargetPort!.Alignment == PortAlignment.Left || link.TargetPort.Alignment == PortAlignment.Right) ?
+                $"{cX.ToInvariantString()} {tY.ToInvariantString()}" :
+                $"{tX.ToInvariantString()} {cY.ToInvariantString()}";
+
             return $"M {sX.ToInvariantString()} {sY.ToInvariantString()} " +
-                $"C {((sX + tX) / 2).ToInvariantString()} {sY.ToInvariantString()}," +
-                $" {((sX + tX) / 2).ToInvariantString()} {tY.ToInvariantString()}," +
+                $"C {curvePoint1}," +
+                $" {cuvePoint2}," +
                 $" {tX.ToInvariantString()} {tY.ToInvariantString()}";
         }
 

--- a/src/Blazor.Diagrams/wwwroot/default.styles.css
+++ b/src/Blazor.Diagrams/wwwroot/default.styles.css
@@ -22,10 +22,12 @@
     .default-node .port {
         width: 20px;
         height: 20px;
+        margin: -10px;
         border-radius: 50%;
         background-color: #f5f5f5;
         border: 1px solid #d4d4d4;
         cursor: pointer;
+        position: absolute;
     }
 
         .default-node .port:hover, .default-node .port.has-links {
@@ -33,27 +35,43 @@
         }
 
         .default-node .port.bottom {
-            position: absolute;
-            bottom: -10px;
-            left: 40px;
+            bottom: 0px;
+            left: 50%;
+        }
+
+        .default-node .port.bottomleft {            
+            bottom: 0px;
+            left: 0px;
+        }
+
+        .default-node .port.bottomright {
+            bottom: 0px;
+            right: 0px;
         }
 
         .default-node .port.top {
-            position: absolute;
-            top: -10px;
-            left: 40px;
+            top: 0px;
+            left: 50%;
+        }
+
+        .default-node .port.topleft {
+            top: 0px;
+            left: 0px;
+        }
+
+        .default-node .port.topright {
+            top: 0px;
+            right: 0px;
         }
 
         .default-node .port.left {
-            position: absolute;
-            left: -10px;
-            top: 30px;
+            left: 0px;
+            top: 50%;
         }
 
         .default-node .port.right {
-            position: absolute;
-            right: -10px;
-            top: 30px;
+            right: 0px;
+            top: 50%;
         }
 
 .diagram-navigator.default {


### PR DESCRIPTION
Uses the Source and Target port Alignment values to make a path that connects to the nodes pointing away.  Old method did not point away from the node if port was on Top or Bottom.