### PR TITLE
Version 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Diagrams [1.5.0] - 2021-01-05
+
+## Added
+
+- The ability to have ports on groups.
+- **EXPERIMENTAL/INCOMPLETE** Nested groups. Since `GroupModel` now inherits `NodeMode`, it became possible to have nested groups, but there are still problems with the order of links between groups.
+- A `Class` parameter to `GroupContainer`.
+
+## Changed
+
+- Only rerender groups when necessary.
+- Receiving the same size from `ResizeObserver` doesn't trigger a rerender anymore.
+- Avoid rerendering ports twice to update positions.
+- Avoid rerendering ports when their parent node is moving.
+- Padding is now handled in `GroupModel` instead of `GroupContainer` (UI). This is because the padding is necessary to have accurate size/position in the group model directly.
+
+## Fixed
+
+- Use `@key` when rendering the list of groups. Not using it caused big/weird render times.
+- Groups not showing in Navigator/Overview.
+
+
 ## Diagrams [1.4.2] - 2020-12-30
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `@key` when rendering the list of groups. Not using it caused big/weird render times.
 - Groups not showing in Navigator/Overview.
 
-
 ## Diagrams [1.4.2] - 2020-12-30
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ You can get started very easily & quickly using:
 - Customizable Diagram Overview/Preview/Navigator (on the bottom right by default)
 - Snap to Grid
 - Grouping: [CTRL + ALT + G] to (un)group
-- Clipping: only draw nodes that are visible to the users
+- Groups with ports/links and nested groups (**experimental**)
+- Virtualization: only draw nodes that are visible to the users
 - Algorithms
 
 ## Preview

--- a/samples/SharedDemo/Demos/Grouping.razor.cs
+++ b/samples/SharedDemo/Demos/Grouping.razor.cs
@@ -18,11 +18,16 @@ namespace SharedDemo.Demos
 
             var node1 = NewNode(50, 50);
             var node2 = NewNode(250, 250);
-            var node3 = NewNode(450, 100);
+            var node3 = NewNode(500, 100);
+
+            var group = diagramManager.Group(node1, node2);
+            group.AddPort(PortAlignment.Bottom);
+            group.AddPort(PortAlignment.Top);
+            group.AddPort(PortAlignment.Left);
+            group.AddPort(PortAlignment.Right);
 
             diagramManager.AddLink(node1.GetPort(PortAlignment.Right), node2.GetPort(PortAlignment.Left));
-            diagramManager.AddLink(node2.GetPort(PortAlignment.Right), node3.GetPort(PortAlignment.Left));
-            diagramManager.Group(node1, node2);
+            diagramManager.AddLink(group.GetPort(PortAlignment.Right), node3.GetPort(PortAlignment.Left));
             diagramManager.AddNode(node3);
         }
 

--- a/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
+++ b/src/Blazor.Diagrams.Core/Blazor.Diagrams.Core.csproj
@@ -7,10 +7,10 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>zHaytam</Authors>
     <Description>A fully customizable and extensible all-purpose diagrams library for Blazor</Description>
-    <AssemblyVersion>1.4.2</AssemblyVersion>
-    <FileVersion>1.4.2</FileVersion>
+    <AssemblyVersion>1.5.0</AssemblyVersion>
+    <FileVersion>1.5.0</FileVersion>
     <RepositoryUrl>https://github.com/zHaytam/Blazor.Diagrams</RepositoryUrl>
-    <Version>1.4.2</Version>
+    <Version>1.5.0</Version>
     <PackageId>Z.Blazor.Diagrams.Core</PackageId>
     <PackageTags>blazor diagrams diagramming svg drag</PackageTags>
     <Product>Z.Blazor.Diagrams.Core</Product>

--- a/src/Blazor.Diagrams.Core/Default/GroupingSubManager.cs
+++ b/src/Blazor.Diagrams.Core/Default/GroupingSubManager.cs
@@ -20,36 +20,36 @@ namespace Blazor.Diagrams.Core.Default
             if (DiagramManager.SelectedModels.Count == 0)
                 return;
 
-            if (e.CtrlKey && e.AltKey && e.Key.Equals("g", StringComparison.InvariantCultureIgnoreCase))
+            if (!e.CtrlKey || !e.AltKey || !e.Key.Equals("g", StringComparison.InvariantCultureIgnoreCase))
+                return;
+
+            var selectedNodes = DiagramManager.SelectedModels
+                .Where(m => m is NodeModel)
+                .Select(m => (NodeModel)m)
+                .ToArray();
+
+            var nodesWithGroup = selectedNodes.Where(n => n.Group != null).ToArray();
+            if (nodesWithGroup.Length > 0)
             {
-                var selectedNodes = DiagramManager.SelectedModels
-                    .Where(m => m is NodeModel)
-                    .Select(m => (NodeModel)m)
-                    .ToArray();
-
-                var nodesWithGroup = selectedNodes.Where(n => n.Group != null).ToArray();
-                if (nodesWithGroup.Length > 0)
+                // Ungroup
+                foreach (var group in nodesWithGroup.GroupBy(n => n.Group!).Select(g => g.Key))
                 {
-                    // Ungroup
-                    foreach (var group in nodesWithGroup.GroupBy(n => n.Group!).Select(g => g.Key))
-                    {
-                        DiagramManager.Ungroup(group);
-                    }
+                    DiagramManager.Ungroup(group);
                 }
-                else
-                {
-                    // Group
-                    if (selectedNodes.Length < 2)
-                        return;
+            }
+            else
+            {
+                // Group
+                if (selectedNodes.Length < 2)
+                    return;
 
-                    if (selectedNodes.Any(n => n.Group != null))
-                        return;
+                if (selectedNodes.Any(n => n.Group != null))
+                    return;
 
-                    if (selectedNodes.Select(n => n.Layer).Distinct().Count() > 1)
-                        return;
+                if (selectedNodes.Select(n => n.Layer).Distinct().Count() > 1)
+                    return;
 
-                    DiagramManager.Group(selectedNodes);
-                }
+                DiagramManager.Group(selectedNodes);
             }
         }
 

--- a/src/Blazor.Diagrams.Core/DiagramManager.cs
+++ b/src/Blazor.Diagrams.Core/DiagramManager.cs
@@ -60,7 +60,7 @@ namespace Blazor.Diagrams.Core
         }
 
         public IReadOnlyCollection<NodeModel> Nodes => _nodes;
-        public IEnumerable<LinkModel> AllLinks => _nodes.SelectMany(n => n.AllLinks).Distinct();
+        public IEnumerable<LinkModel> AllLinks => _nodes.SelectMany(n => n.AllLinks).Union(_groups.SelectMany(g => g.AllLinks)).Distinct();
         public IReadOnlyCollection<SelectableModel> SelectedModels => _selectedModels;
         public IReadOnlyCollection<GroupModel> Groups => _groups;
         public Rectangle? Container { get; internal set; }

--- a/src/Blazor.Diagrams.Core/DiagramManager.cs
+++ b/src/Blazor.Diagrams.Core/DiagramManager.cs
@@ -140,6 +140,10 @@ namespace Blazor.Diagrams.Core
 
             source.Refresh();
             target?.Refresh();
+
+            source.Parent.Group?.Refresh();
+            target?.Parent.Group?.Refresh();
+
             LinkAdded?.Invoke(link);
             Changed?.Invoke();
             return link;
@@ -156,6 +160,10 @@ namespace Blazor.Diagrams.Core
             link.SetTargetPort(targetPort);
             link.Refresh();
             targetPort.Refresh();
+
+            link.SourcePort.Parent.Group?.Refresh();
+            targetPort?.Parent.Group?.Refresh();
+
             LinkAttached?.Invoke(link);
         }
 
@@ -167,6 +175,9 @@ namespace Blazor.Diagrams.Core
             LinkRemoved?.Invoke(link);
             link.SourcePort.Refresh();
             link.TargetPort?.Refresh();
+
+            link.SourcePort.Parent.Group?.Refresh();
+            link.TargetPort?.Parent.Group?.Refresh();
 
             if (triggerEvent)
             {
@@ -311,7 +322,7 @@ namespace Blazor.Diagrams.Core
         }
 
         public void Refresh() => Changed?.Invoke();
-         
+
         public void ZoomToFit(double margin = 10)
         {
             if (_nodes.Count == 0)

--- a/src/Blazor.Diagrams.Core/Models/Core/Size.cs
+++ b/src/Blazor.Diagrams.Core/Models/Core/Size.cs
@@ -17,7 +17,7 @@
 
         public Size Add(double value) => new Size(Width + value, Height + value);
 
-        public bool Equals(Size size) => size != null && Width == size.Width && Height == size.Height;
+        public bool Equals(Size? size) => size != null && Width == size.Width && Height == size.Height;
 
         public override string ToString() => $"Size(width={Width}, height={Height})";
     }

--- a/src/Blazor.Diagrams.Core/Models/GroupModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/GroupModel.cs
@@ -1,4 +1,5 @@
 ﻿using Blazor.Diagrams.Core.Models.Core;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -66,18 +67,21 @@ namespace Blazor.Diagrams.Core.Models
 
         private void OnNodeChanged(NodeModel node)
         {
-            UpdateDimensions();
-            Refresh();
+            if (UpdateDimensions())
+            {
+                Refresh();
+            }
         }
 
-        private void UpdateDimensions()
+        private bool UpdateDimensions()
         {
             if (Children.Any(n => n.Size == null))
-                return;
+                return false;
 
             (var nodesMinX, var nodesMaxX, var nodesMinY, var nodesMaxY) = _diagramManager.GetNodesRect(Children);
             Size = new Size(nodesMaxX - nodesMinX + _padding * 2, nodesMaxY - nodesMinY + _padding * 2);
             Position = new Point(nodesMinX - _padding, nodesMinY - _padding);
+            return true;
         }
     }
 }

--- a/src/Blazor.Diagrams.Core/Models/GroupModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/GroupModel.cs
@@ -1,5 +1,4 @@
 ﻿using Blazor.Diagrams.Core.Models.Core;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -21,7 +20,7 @@ namespace Blazor.Diagrams.Core.Models
         }
 
         public NodeModel[] Children { get; private set; }
-        public IEnumerable<LinkModel> HandledLinks => Group != null ? Array.Empty<LinkModel>() : Children.SelectMany(c => c.AllLinks).Distinct();
+        public IEnumerable<LinkModel> HandledLinks => Children.SelectMany(c => c.AllLinks).Distinct();
 
         public override void SetPosition(double x, double y)
         {

--- a/src/Blazor.Diagrams.Core/Models/NodeModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/NodeModel.cs
@@ -31,6 +31,9 @@ namespace Blazor.Diagrams.Core.Models
             get => _size;
             set
             {
+                if (value?.Equals(_size) == true)
+                    return;
+
                 _size = value;
                 SizeChanged?.Invoke(this);
             }

--- a/src/Blazor.Diagrams.Core/Models/NodeModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/NodeModel.cs
@@ -62,6 +62,15 @@ namespace Blazor.Diagrams.Core.Models
             _ports.ForEach(p => p.RefreshAll());
         }
 
+        public void ReinitializePorts()
+        {
+            foreach (var port in Ports)
+            {
+                port.Initialized = false;
+                port.Refresh();
+            }
+        }
+
         public bool RemovePort(PortModel port) => _ports.Remove(port);
 
         public override void SetPosition(double x, double y)

--- a/src/Blazor.Diagrams.Core/Models/NodeModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/NodeModel.cs
@@ -70,13 +70,8 @@ namespace Blazor.Diagrams.Core.Models
             var deltaY = y - Position.Y;
             base.SetPosition(x, y);
 
-            // Save some JS calls and update ports directly here
-            foreach (var port in _ports)
-            {
-                port.Position = new Point(port.Position.X + deltaX, port.Position.Y + deltaY);
-            }
-
-            RefreshAll();
+            UpdatePortPositions(deltaX, deltaY);
+            Refresh();
             Moving?.Invoke(this);
         }
 
@@ -84,13 +79,18 @@ namespace Blazor.Diagrams.Core.Models
         {
             base.SetPosition(Position.X + deltaX, Position.Y + deltaY);
 
+            UpdatePortPositions(deltaX, deltaY);
+            Refresh();
+        }
+
+        private void UpdatePortPositions(double deltaX, double deltaY)
+        {
             // Save some JS calls and update ports directly here
             foreach (var port in _ports)
             {
                 port.Position = new Point(port.Position.X + deltaX, port.Position.Y + deltaY);
+                port.RefreshLinks();
             }
-
-            RefreshAll();
         }
     }
 }

--- a/src/Blazor.Diagrams.Core/Models/PortModel.cs
+++ b/src/Blazor.Diagrams.Core/Models/PortModel.cs
@@ -37,8 +37,10 @@ namespace Blazor.Diagrams.Core.Models
         public void RefreshAll()
         {
             Refresh();
-            _links.ForEach(l => l.Refresh());
+            RefreshLinks();
         }
+
+        public void RefreshLinks() => _links.ForEach(l => l.Refresh());
 
         public T GetParent<T>() where T : NodeModel => (T)Parent;
 

--- a/src/Blazor.Diagrams/Blazor.Diagrams.csproj
+++ b/src/Blazor.Diagrams/Blazor.Diagrams.csproj
@@ -5,11 +5,11 @@
     <RazorLangVersion>3.0</RazorLangVersion>
     <Authors>zHaytam</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <AssemblyVersion>1.4.2</AssemblyVersion>
-    <FileVersion>1.4.2</FileVersion>
+    <AssemblyVersion>1.5.0</AssemblyVersion>
+    <FileVersion>1.5.0</FileVersion>
     <RepositoryUrl>https://github.com/zHaytam/Blazor.Diagrams</RepositoryUrl>
     <Description>A fully customizable and extensible all-purpose diagrams library for Blazor</Description>
-    <Version>1.4.2</Version>
+    <Version>1.5.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTags>blazor diagrams diagramming svg drag</PackageTags>
     <PackageId>Z.Blazor.Diagrams</PackageId>

--- a/src/Blazor.Diagrams/Components/DiagramCanvas.razor
+++ b/src/Blazor.Diagrams/Components/DiagramCanvas.razor
@@ -31,7 +31,7 @@
 
         @foreach (var group in DiagramManager.Groups)
         {
-            <GroupRenderer Group="group" />
+            <GroupRenderer @key="group.Id" Group="group" />
         }
 
         @foreach (var node in DiagramManager.Nodes.Where(n => n.Layer == RenderLayer.HTML))

--- a/src/Blazor.Diagrams/Components/Groups/DefaultGroupWidget.razor
+++ b/src/Blazor.Diagrams/Components/Groups/DefaultGroupWidget.razor
@@ -6,4 +6,9 @@
 <GroupContainer Group="Group" Class="default">
     <GroupLinks></GroupLinks>
     <GroupNodes></GroupNodes>
+
+    @foreach (var port in Group.Ports)
+    {
+        <PortRenderer Port="port" Class="group-port"></PortRenderer>
+    }
 </GroupContainer>

--- a/src/Blazor.Diagrams/Components/Groups/DefaultGroupWidget.razor
+++ b/src/Blazor.Diagrams/Components/Groups/DefaultGroupWidget.razor
@@ -3,7 +3,7 @@
     public GroupModel Group { get; set; }
 }
 
-<GroupContainer Group="Group" Padding="30">
+<GroupContainer Group="Group">
     <GroupLinks></GroupLinks>
     <GroupNodes></GroupNodes>
 </GroupContainer>

--- a/src/Blazor.Diagrams/Components/Groups/DefaultGroupWidget.razor
+++ b/src/Blazor.Diagrams/Components/Groups/DefaultGroupWidget.razor
@@ -3,7 +3,7 @@
     public GroupModel Group { get; set; }
 }
 
-<GroupContainer Group="Group">
+<GroupContainer Group="Group" Class="default">
     <GroupLinks></GroupLinks>
     <GroupNodes></GroupNodes>
 </GroupContainer>

--- a/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor
+++ b/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor
@@ -1,5 +1,6 @@
 ﻿<div class="group @(Group.Selected ? " selected" : "")"
-     style="top: @(Y.ToInvariantString())px; left: @(X.ToInvariantString())px;width: @(Width.ToInvariantString())px; height: @(Height.ToInvariantString())px;"
+     style="top: @(Group.Position.Y.ToInvariantString())px; left: @(Group.Position.X.ToInvariantString())px;
+            width: @(Group.Size.Width.ToInvariantString())px; height: @(Group.Size.Height.ToInvariantString())px;"
      @onmousedown="OnMouseDown"
      @onmousedown:stopPropagation
      @onmouseup="OnMouseUp"

--- a/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor
+++ b/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor
@@ -1,4 +1,4 @@
-﻿<div class="group @(Group.Selected ? " selected" : "")"
+﻿<div class="group@(Group.Selected ? " selected" : "") @(string.IsNullOrEmpty(Class) ? "" : $" {Class}")"
      style="top: @(Group.Position.Y.ToInvariantString())px; left: @(Group.Position.X.ToInvariantString())px;
             width: @(Group.Size.Width.ToInvariantString())px; height: @(Group.Size.Height.ToInvariantString())px;"
      @onmousedown="OnMouseDown"

--- a/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor
+++ b/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor
@@ -4,7 +4,7 @@
      @onmousedown:stopPropagation
      @onmouseup="OnMouseUp"
      @onmouseup:stopPropagation>
-    <CascadingValue Value="this">
+    <CascadingValue Value="Group">
         @ChildContent
     </CascadingValue>
 </div>

--- a/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor.cs
+++ b/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor.cs
@@ -1,13 +1,18 @@
 ﻿using Blazor.Diagrams.Core;
 using Blazor.Diagrams.Core.Models;
+using Blazor.Diagrams.Core.Models.Core;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using System;
+using System.Diagnostics;
 
 namespace Blazor.Diagrams.Components.Groups
 {
     public partial class GroupContainer : IDisposable
     {
+        private readonly Stopwatch _stopwatch = new Stopwatch();
+        private int _totalRenders = 0;
+
         [Parameter]
         public GroupModel Group { get; set; }
 
@@ -20,10 +25,10 @@ namespace Blazor.Diagrams.Components.Groups
         [CascadingParameter(Name = "DiagramManager")]
         public DiagramManager DiagramManager { get; set; }
 
-        public double X => Group.Position.X - Padding;
-        public double Y => Group.Position.Y - Padding;
-        public double Width => Group.Size.Width + Padding * 2;
-        public double Height => Group.Size.Height + Padding * 2;
+        public double X => Group.Position.X;
+        public double Y => Group.Position.Y;
+        public double Width => Group.Size.Width;
+        public double Height => Group.Size.Height;
 
         public void Dispose()
         {
@@ -35,7 +40,24 @@ namespace Blazor.Diagrams.Components.Groups
             Group.Changed += OnGroupChanged;
         }
 
-        private void OnGroupChanged() => StateHasChanged(); // Todo: Use _shouldRender pattern
+        protected override bool ShouldRender()
+        {
+            _stopwatch.Start();
+            return true;
+        }
+
+        protected override void OnAfterRender(bool firstRender)
+        {
+            base.OnAfterRender(firstRender);
+            _totalRenders++;
+            Console.WriteLine($"Group: {Group.Id}, Render: #{_totalRenders}, Time: {_stopwatch.Elapsed.TotalMilliseconds}ms");
+            _stopwatch.Reset();
+        }
+
+        private void OnGroupChanged()
+        {
+            StateHasChanged(); // Todo: Use _shouldRender pattern
+        }
 
         private void OnMouseDown(MouseEventArgs e) => DiagramManager.OnMouseDown(Group, e);
 

--- a/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor.cs
+++ b/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor.cs
@@ -14,9 +14,6 @@ namespace Blazor.Diagrams.Components.Groups
         public GroupModel Group { get; set; }
 
         [Parameter]
-        public ushort Padding { get; set; }
-
-        [Parameter]
         public RenderFragment ChildContent { get; set; }
 
         [CascadingParameter(Name = "DiagramManager")]

--- a/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor.cs
+++ b/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor.cs
@@ -19,11 +19,6 @@ namespace Blazor.Diagrams.Components.Groups
         [CascadingParameter(Name = "DiagramManager")]
         public DiagramManager DiagramManager { get; set; }
 
-        public double X => Group.Position.X;
-        public double Y => Group.Position.Y;
-        public double Width => Group.Size.Width;
-        public double Height => Group.Size.Height;
-
         public void Dispose()
         {
             Group.Changed -= OnGroupChanged;

--- a/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor.cs
+++ b/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor.cs
@@ -1,5 +1,6 @@
 ﻿using Blazor.Diagrams.Core;
 using Blazor.Diagrams.Core.Models;
+using Blazor.Diagrams.Core.Models.Core;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using System;
@@ -9,6 +10,7 @@ namespace Blazor.Diagrams.Components.Groups
     public partial class GroupContainer : IDisposable
     {
         private bool _shouldRender = true;
+        private Size _lastSize;
 
         [Parameter]
         public GroupModel Group { get; set; }
@@ -27,7 +29,7 @@ namespace Blazor.Diagrams.Components.Groups
             Group.Changed -= OnGroupChanged;
         }
 
-        protected override void OnParametersSet()
+        protected override void OnInitialized()
         {
             Group.Changed += OnGroupChanged;
         }
@@ -41,6 +43,21 @@ namespace Blazor.Diagrams.Components.Groups
             }
 
             return false;
+        }
+
+        protected override void OnAfterRender(bool firstRender)
+        {
+            if (Size.Zero.Equals(Group.Size))
+                return;
+
+            // Update the port positions (and links) when the size of the group changes
+            // This will save us some JS trips as well as useless rerenders
+
+            if (_lastSize == null || !_lastSize.Equals(Group.Size))
+            {
+                Group.ReinitializePorts();
+                _lastSize = Group.Size;
+            }
         }
 
         private void OnGroupChanged()

--- a/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor.cs
+++ b/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor.cs
@@ -1,17 +1,14 @@
 ﻿using Blazor.Diagrams.Core;
 using Blazor.Diagrams.Core.Models;
-using Blazor.Diagrams.Core.Models.Core;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using System;
-using System.Diagnostics;
 
 namespace Blazor.Diagrams.Components.Groups
 {
     public partial class GroupContainer : IDisposable
     {
-        private readonly Stopwatch _stopwatch = new Stopwatch();
-        private int _totalRenders = 0;
+        private bool _shouldRender = true;
 
         [Parameter]
         public GroupModel Group { get; set; }
@@ -42,21 +39,19 @@ namespace Blazor.Diagrams.Components.Groups
 
         protected override bool ShouldRender()
         {
-            _stopwatch.Start();
-            return true;
-        }
+            if (_shouldRender)
+            {
+                _shouldRender = false;
+                return true;
+            }
 
-        protected override void OnAfterRender(bool firstRender)
-        {
-            base.OnAfterRender(firstRender);
-            _totalRenders++;
-            Console.WriteLine($"Group: {Group.Id}, Render: #{_totalRenders}, Time: {_stopwatch.Elapsed.TotalMilliseconds}ms");
-            _stopwatch.Reset();
+            return false;
         }
 
         private void OnGroupChanged()
         {
-            StateHasChanged(); // Todo: Use _shouldRender pattern
+            _shouldRender = true;
+            StateHasChanged();
         }
 
         private void OnMouseDown(MouseEventArgs e) => DiagramManager.OnMouseDown(Group, e);

--- a/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor.cs
+++ b/src/Blazor.Diagrams/Components/Groups/GroupContainer.razor.cs
@@ -14,6 +14,9 @@ namespace Blazor.Diagrams.Components.Groups
         public GroupModel Group { get; set; }
 
         [Parameter]
+        public string Class { get; set; }
+
+        [Parameter]
         public RenderFragment ChildContent { get; set; }
 
         [CascadingParameter(Name = "DiagramManager")]

--- a/src/Blazor.Diagrams/Components/Groups/GroupLinks.razor
+++ b/src/Blazor.Diagrams/Components/Groups/GroupLinks.razor
@@ -5,7 +5,7 @@
 
 <svg class="layer"
      style="top: @((-Group.Position.Y).ToInvariantString())px; left: @((-Group.Position.X).ToInvariantString())px">
-    @foreach (var link in Group.Group.HandledLinks)
+    @foreach (var link in Group.HandledLinks)
     {
         <LinkRenderer @key="link.Id" Link="link"></LinkRenderer>
     }

--- a/src/Blazor.Diagrams/Components/Groups/GroupLinks.razor
+++ b/src/Blazor.Diagrams/Components/Groups/GroupLinks.razor
@@ -5,7 +5,7 @@
 
 <svg class="layer"
      style="top: @((-GroupContainer.Y).ToInvariantString())px; left: @((-GroupContainer.X).ToInvariantString())px">
-    @foreach (var link in GroupContainer.Group.AllLinks)
+    @foreach (var link in GroupContainer.Group.HandledLinks)
     {
         <LinkRenderer @key="link.Id" Link="link"></LinkRenderer>
     }

--- a/src/Blazor.Diagrams/Components/Groups/GroupLinks.razor
+++ b/src/Blazor.Diagrams/Components/Groups/GroupLinks.razor
@@ -1,11 +1,11 @@
 ﻿@code {
     [CascadingParameter]
-    public GroupContainer GroupContainer { get; set; }
+    public GroupModel Group { get; set; }
 } 
 
 <svg class="layer"
-     style="top: @((-GroupContainer.Y).ToInvariantString())px; left: @((-GroupContainer.X).ToInvariantString())px">
-    @foreach (var link in GroupContainer.Group.HandledLinks)
+     style="top: @((-Group.Position.Y).ToInvariantString())px; left: @((-Group.Position.X).ToInvariantString())px">
+    @foreach (var link in Group.Group.HandledLinks)
     {
         <LinkRenderer @key="link.Id" Link="link"></LinkRenderer>
     }

--- a/src/Blazor.Diagrams/Components/Groups/GroupNodes.razor
+++ b/src/Blazor.Diagrams/Components/Groups/GroupNodes.razor
@@ -5,7 +5,7 @@
 
 <div class="layer"
      style="top: @((-Group.Position.Y).ToInvariantString())px; left: @((-Group.Position.X).ToInvariantString())px">
-    @foreach (var node in Group.Group.Children)
+    @foreach (var node in Group.Children)
     {
         if (node is GroupModel g)
         {

--- a/src/Blazor.Diagrams/Components/Groups/GroupNodes.razor
+++ b/src/Blazor.Diagrams/Components/Groups/GroupNodes.razor
@@ -7,6 +7,13 @@
      style="top: @((-GroupContainer.Y).ToInvariantString())px; left: @((-GroupContainer.X).ToInvariantString())px">
     @foreach (var node in GroupContainer.Group.Children)
     {
-        <NodeRenderer @key="node.Id" Node="node"></NodeRenderer>
+        if (node is GroupModel g)
+        {
+            <GroupRenderer @key="g.Id" Group="g"></GroupRenderer>
+        }
+        else
+        {
+            <NodeRenderer @key="node.Id" Node="node"></NodeRenderer>
+        }
     }
 </div>

--- a/src/Blazor.Diagrams/Components/Groups/GroupNodes.razor
+++ b/src/Blazor.Diagrams/Components/Groups/GroupNodes.razor
@@ -1,11 +1,11 @@
 ﻿@code {
     [CascadingParameter]
-    public GroupContainer GroupContainer { get; set; }
+    public GroupModel Group { get; set; }
 }
 
 <div class="layer"
-     style="top: @((-GroupContainer.Y).ToInvariantString())px; left: @((-GroupContainer.X).ToInvariantString())px">
-    @foreach (var node in GroupContainer.Group.Children)
+     style="top: @((-Group.Position.Y).ToInvariantString())px; left: @((-Group.Position.X).ToInvariantString())px">
+    @foreach (var node in Group.Group.Children)
     {
         if (node is GroupModel g)
         {

--- a/src/Blazor.Diagrams/Components/Navigator.razor
+++ b/src/Blazor.Diagrams/Components/Navigator.razor
@@ -31,6 +31,36 @@
                           height="@height.ToInvariantString()"></rect>
                 </g>
             }
+
+            @foreach (var group in DiagramManager.Groups.Where(g => !Size.Zero.Equals(g.Size)))
+            {
+                var left = (Math.Max(0, group.Position.X * DiagramManager.Zoom) + addedNodeX) * XFactor;
+                var top = (Math.Max(0, group.Position.Y * DiagramManager.Zoom) + addedNodeY) * YFactor;
+                var width = group.Size.Width * DiagramManager.Zoom * XFactor;
+                var height = group.Size.Height * DiagramManager.Zoom * YFactor;
+
+                <g @key="group.Id" transform="translate(@left.ToInvariantString(), @top.ToInvariantString())">
+                    <rect stroke="#40babd"
+                          stroke-width="2"
+                          fill="#ffffff"
+                          width="@width.ToInvariantString()"
+                          height="@height.ToInvariantString()"></rect>
+                </g>
+
+                @foreach (var child in group.Children)
+                {
+                    var childLeft = (Math.Max(0, child.Position.X * DiagramManager.Zoom) + addedNodeX) * XFactor;
+                    var childTop = (Math.Max(0, child.Position.Y * DiagramManager.Zoom) + addedNodeY) * YFactor;
+                    var childWidth = child.Size.Width * DiagramManager.Zoom * XFactor;
+                    var childHeight = child.Size.Height * DiagramManager.Zoom * YFactor;
+
+                    <g @key="child.Id" transform="translate(@childLeft.ToInvariantString(), @childTop.ToInvariantString())">
+                        <rect fill="#40babd"
+                              width="@childWidth.ToInvariantString()"
+                              height="@childHeight.ToInvariantString()"></rect>
+                    </g>
+                }
+            }
         </svg>
     </div>
 }

--- a/src/Blazor.Diagrams/Components/Renderers/NodeRenderer.cs
+++ b/src/Blazor.Diagrams/Components/Renderers/NodeRenderer.cs
@@ -52,6 +52,9 @@ namespace Blazor.Diagrams.Components.Renderers
             if (Size.Zero.Equals(size))
                 return;
 
+            if (size.Equals(Node.Size))
+                return;
+
             Node.Size = size;
             Node.Refresh();
 

--- a/src/Blazor.Diagrams/Components/Renderers/NodeRenderer.cs
+++ b/src/Blazor.Diagrams/Components/Renderers/NodeRenderer.cs
@@ -57,12 +57,7 @@ namespace Blazor.Diagrams.Components.Renderers
 
             Node.Size = size;
             Node.Refresh();
-
-            foreach (var port in Node.Ports)
-            {
-                port.Initialized = false;
-                port.Refresh();
-            }
+            Node.ReinitializePorts();
         }
 
         protected override void OnInitialized()

--- a/src/Blazor.Diagrams/Components/Renderers/NodeRenderer.cs
+++ b/src/Blazor.Diagrams/Components/Renderers/NodeRenderer.cs
@@ -61,7 +61,7 @@ namespace Blazor.Diagrams.Components.Renderers
             foreach (var port in Node.Ports)
             {
                 port.Initialized = false;
-                port.RefreshAll();
+                port.Refresh();
             }
         }
 

--- a/src/Blazor.Diagrams/_Imports.razor
+++ b/src/Blazor.Diagrams/_Imports.razor
@@ -3,3 +3,4 @@
 @using Blazor.Diagrams.Core.Extensions;
 @using Blazor.Diagrams.Core.Models;
 @using Blazor.Diagrams.Components.Renderers
+@using Blazor.Diagrams.Core.Models.Core;

--- a/src/Blazor.Diagrams/wwwroot/default.styles.css
+++ b/src/Blazor.Diagrams/wwwroot/default.styles.css
@@ -88,11 +88,11 @@
     border: 2px solid #40babd;
 }
 
-.group {
+.group.default {
     outline: 2px solid black;
     background: rgb(198, 198, 198);
 }
 
-    .group.selected {
+    .group.default.selected {
         outline: 2px solid #6e9fd4;
     }

--- a/src/Blazor.Diagrams/wwwroot/default.styles.css
+++ b/src/Blazor.Diagrams/wwwroot/default.styles.css
@@ -19,7 +19,7 @@
             border: 1px solid #6e9fd4;
         }
 
-    .default-node .port {
+    .default-node .port, .default.group .port {
         width: 20px;
         height: 20px;
         margin: -10px;
@@ -30,46 +30,46 @@
         position: absolute;
     }
 
-        .default-node .port:hover, .default-node .port.has-links {
+        .default-node .port:hover, .default-node .port.has-links, .default.group .port.has-links {
             background-color: black;
         }
 
-        .default-node .port.bottom {
+        .default-node .port.bottom, .default.group .port.bottom {
             bottom: 0px;
             left: 50%;
         }
 
-        .default-node .port.bottomleft {            
+        .default-node .port.bottomleft, .default.group .port.bottomleft {
             bottom: 0px;
             left: 0px;
         }
 
-        .default-node .port.bottomright {
+        .default-node .port.bottomright, .default.group .port.bottomright {
             bottom: 0px;
             right: 0px;
         }
 
-        .default-node .port.top {
+        .default-node .port.top, .default.group .port.top {
             top: 0px;
             left: 50%;
         }
 
-        .default-node .port.topleft {
+        .default-node .port.topleft, .default.group .port.topleft {
             top: 0px;
             left: 0px;
         }
 
-        .default-node .port.topright {
+        .default-node .port.topright, .default.group .port.topright {
             top: 0px;
             right: 0px;
         }
 
-        .default-node .port.left {
+        .default-node .port.left, .default.group .port.left {
             left: 0px;
             top: 50%;
         }
 
-        .default-node .port.right {
+        .default-node .port.right, .default.group .port.right {
             right: 0px;
             top: 50%;
         }


### PR DESCRIPTION
Fixes #60 
Fixes #57 

## Added

- The ability to have ports on groups.
- **EXPERIMENTAL/INCOMPLETE** Nested groups. Since `GroupModel` now inherits `NodeMode`, it became possible to have nested groups, but there are still problems with the order of links between groups.
- A `Class` parameter to `GroupContainer`.

## Changed

- Only rerender groups when necessary.
- Receiving the same size from `ResizeObserver` doesn't trigger a rerender anymore.
- Avoid rerendering ports twice to update positions.
- Avoid rerendering ports when their parent node is moving.
- Padding is now handled in `GroupModel` instead of `GroupContainer` (UI). This is because the padding is necessary to have accurate size/position in the group model directly.

## Fixed

- Use `@key` when rendering the list of groups. Not using it caused big/weird render times.
- Groups not showing in Navigator/Overview.